### PR TITLE
Add upgrade height checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 config/.env
-./idea
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config/.env
+./idea

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ubuntu 20.04 / 1 VCPU / 2 GB RAM / 20 GB SSD
 ### Install monitoring stack
 To install monitirng stack you can use one-liner below
 ```
-wget -O install_monitoring.sh https://raw.githubusercontent.com/sei-protocol/sei-node-monitoring/master/install_monitoring.sh && chmod +x install_monitoring.sh && ./install_monitoring.sh
+wget -O install_monitoring.sh https://raw.githubusercontent.com/sei-protocol/sei-node-monitoring/master/install_monitoring.sh && chmod +x install_monitoring.sh && ./install_monitoring.sh $NODE_IP
 ```
 
 ### Add validator into _prometheus_ configuration file

--- a/install_monitoring.sh
+++ b/install_monitoring.sh
@@ -64,12 +64,16 @@ git clone https://github.com/sei-protocol/sei-node-monitoring.git
 
 chmod +x /home/ubuntu/sei-node-monitoring/add_validator.sh
 # Insert starting upgrade height
-UPGRADE_HEIGHT=0 envsubst < alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+UPGRADE_HEIGHT=0 envsubst '${UPGRADE_HEIGHT}' < /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
 
 echo -e "\e[1m\e[32m5. Installing upgrade checker ... \e[0m"
 curl -LO https://go.dev/dl/go1.18beta1.linux-amd64.tar.gz
 tar -C /usr/local -xzf go1.18beta1.linux-amd64.tar.gz
-git clone https://github.com/sei-protocol/sei-chain.git && cd sei-chain && make install
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+source ~/.bashrc
+cd /home/ubuntu/ && git clone https://github.com/sei-protocol/sei-chain.git && cd sei-chain && make install
 touch /var/log/upgrade-checker.log
 chmod +x /home/ubuntu/sei-node-monitoring/upgrade-checker.sh
-(sudo crontab -l 2>/dev/null; echo "* * * * */home/ubuntu/sei-node-monitoring/upgrade-checker.sh $1 >> /var/log/upgrade-checker.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "* * * * * /home/ubuntu/sei-node-monitoring/upgrade-checker.sh $1 >> /var/log/upgrade-checker.log 2>&1") | crontab -

--- a/install_monitoring.sh
+++ b/install_monitoring.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ -z "$1" ]
+  then
+    echo "Node IP must be provided"
+fi
 echo "=================================================="
 echo -e "\033[0;35m"
 echo " :::    ::: ::::::::::: ::::    :::  ::::::::  :::::::::  :::::::::: ::::::::  ";
@@ -59,3 +63,13 @@ rm -rf cosmos_node_monitoring
 git clone https://github.com/sei-protocol/sei-node-monitoring.git
 
 chmod +x /home/ubuntu/sei-node-monitoring/add_validator.sh
+# Insert starting upgrade height
+UPGRADE_HEIGHT=0 envsubst < alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+
+echo -e "\e[1m\e[32m5. Installing upgrade checker ... \e[0m"
+curl -LO https://go.dev/dl/go1.18beta1.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.18beta1.linux-amd64.tar.gz
+git clone https://github.com/sei-protocol/sei-chain.git && cd sei-chain && make install
+touch /var/log/upgrade-checker.log
+chmod +x /home/ubuntu/sei-node-monitoring/upgrade-checker.sh
+(sudo crontab -l 2>/dev/null; echo "* * * * */home/ubuntu/sei-node-monitoring/upgrade-checker.sh $1 >> /var/log/upgrade-checker.log 2>&1") | crontab -

--- a/prometheus/alerts/alert.rules.TEMPLATE
+++ b/prometheus/alerts/alert.rules.TEMPLATE
@@ -15,7 +15,7 @@ groups:
 
 ### Alert for upgrades
     - alert: ApproachingUpgradeHeight
-      expr: (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) < 1000 and (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) > 0
+      expr: (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) < 2000 and (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) > 0
       for: 2m
       annotations:
         title: 'Approaching upgrade height.'

--- a/prometheus/alerts/alert.rules.TEMPLATE
+++ b/prometheus/alerts/alert.rules.TEMPLATE
@@ -14,14 +14,14 @@ groups:
         severity: 'critical'
 
 ### Alert for upgrades
-#    - alert: ApproachingUpgradeHeight
-#      expr: (681000 - tendermint_consensus_latest_block_height) < 1000 and (681000 - tendermint_consensus_latest_block_height) > 0
-#      for: 2m
-#      annotations:
-#        title: 'Approaching upgrade height.'
-#        description: 'We are 1000 blocks away from the upgrade height defined above. Please prepare to perform upgrade'
-#      labels:
-#        severity: 'critical'
+    - alert: ApproachingUpgradeHeight
+      expr: (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) < 1000 and (${UPGRADE_HEIGHT} - tendermint_consensus_latest_block_height) > 0
+      for: 2m
+      annotations:
+        title: 'Approaching upgrade height.'
+        description: 'We are 2000 blocks away from the upgrade height defined above. Please prepare to perform upgrade'
+      labels:
+        severity: 'critical'
 
     - alert: ChainHalted
       expr: rate(tendermint_consensus_latest_block_height[1m]) == 0

--- a/upgrade-checker.sh
+++ b/upgrade-checker.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+NODE=$(cat )
+echo "$(date +%D-%H:%M:%S)" "Checking for any upgrades"  >> /var/log/upgrade-checker.log
+~/go/bin/seid q upgrade plan --output json | jq -r .height
+if $?; then
+  HEIGHT=$(~/go/bin/seid q upgrade plan --output json --node tcp://$NODE:26657| jq -r .height)
+  echo "$(date +%D-%H:%M:%S)" "Upgrade found at $HEIGHT. Setting alert and restart alertmanager"
+  UPGRADE_HEIGHT=$HEIGHT envsubst < alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+  docker compose down && docker compose up -d
+else
+  echo "$(date +%D-%H:%M:%S)" "No upgrade found" >> /var/log/upgrade-checker.log
+fi

--- a/upgrade-checker.sh
+++ b/upgrade-checker.sh
@@ -6,8 +6,8 @@ status=$?
 if [ $status -eq 0 ]; then
   HEIGHT=$(~/go/bin/seid q upgrade plan --output json --node tcp://$NODE:26657| jq -r .height)
   echo "$(date +%D-%H:%M:%S)" "Upgrade found at $HEIGHT. Setting alert and restart alertmanager"
-  UPGRADE_HEIGHT=$HEIGHT envsubst < /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
-  docker compose down && docker compose up -d
+  UPGRADE_HEIGHT=$HEIGHT envsubst '${UPGRADE_HEIGHT}' < /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+  cd /home/ubuntu/sei-node-monitoring/ && docker compose down && docker compose up -d
 else
   echo "$(date +%D-%H:%M:%S)" "No upgrade found" >> /var/log/upgrade-checker.log
 fi

--- a/upgrade-checker.sh
+++ b/upgrade-checker.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-NODE=$(cat )
+NODE=$1
 echo "$(date +%D-%H:%M:%S)" "Checking for any upgrades"  >> /var/log/upgrade-checker.log
-~/go/bin/seid q upgrade plan --output json | jq -r .height
-if $?; then
+echo $(~/go/bin/seid q upgrade plan --output json --node tcp://$NODE:26657| jq -r .height)
+status=$?
+if [ $status -eq 0 ]; then
   HEIGHT=$(~/go/bin/seid q upgrade plan --output json --node tcp://$NODE:26657| jq -r .height)
   echo "$(date +%D-%H:%M:%S)" "Upgrade found at $HEIGHT. Setting alert and restart alertmanager"
-  UPGRADE_HEIGHT=$HEIGHT envsubst < alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+  UPGRADE_HEIGHT=$HEIGHT envsubst < /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
   docker compose down && docker compose up -d
 else
   echo "$(date +%D-%H:%M:%S)" "No upgrade found" >> /var/log/upgrade-checker.log


### PR DESCRIPTION
This PR creates a cron job for upgrade-checker.sh. It queries for an upgrade plans on a node, and if one exists, substitutes the ${HEIGHT} variable to generate alert.rules from alert.rules.TEMPLATE.
<img width="941" alt="image" src="https://user-images.githubusercontent.com/3821073/182497682-bd7f6280-070f-4df3-a0d2-ddf2aa99d296.png">

```
root@ip-172-31-12-128:/home/ubuntu/sei-node-monitoring# tail /var/log/upgrade-checker.log
Container prometheus  Starting
Container alerta_db  Starting
Container grafana  Starting
Container alertmanager  Started
Container alertmanager-bot  Started
Container grafana  Started
Container prometheus  Started
Container alerta_db  Started
Container alerta  Starting
Container alerta  Started
```