### PR TITLE
Add PD service key to setup

### DIFF
--- a/install_monitoring.sh
+++ b/install_monitoring.sh
@@ -65,6 +65,10 @@ git clone https://github.com/sei-protocol/sei-node-monitoring.git
 chmod +x /home/ubuntu/sei-node-monitoring/add_validator.sh
 # Insert starting upgrade height
 UPGRADE_HEIGHT=0 envsubst '${UPGRADE_HEIGHT}' < /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/alerts/alert.rules
+# Insert PagerDuty service key 
+envsubst < /home/ubuntu/sei-node-monitoring/prometheus/alert_manager/alertmanager.yml.TEMPLATE > /home/ubuntu/sei-node-monitoring/prometheus/prometheus/alert_manager/alertmanager.yml
+
+
 
 echo -e "\e[1m\e[32m5. Installing upgrade checker ... \e[0m"
 curl -LO https://go.dev/dl/go1.18beta1.linux-amd64.tar.gz

--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -19,4 +19,4 @@ route:
 receivers:
 - name: 'seinetwork-rules'
   pagerduty_configs:
-    - service_key: 'REPLACEME'
+    - service_key: '${PAGERDUTY_SERVICE_KEY}'


### PR DESCRIPTION
Adds Pagerduty to the service key setup so new monitoring nodes come up with the right service key. I manually exported the env variable in the already deployed atlantic-1 chain 


Tested command locally. 
```
 ~/sei/sei-node-monitoring   setup-pd-key  export PAGERDUTY_SERVICE_KEY=abc123                                                       130 ↵  10356  22:56:41 
 ~/sei/sei-node-monitoring   setup-pd-key  envsubst < prometheus/alert_manager/alertmanager.yml.TEMPLATE > prometheus/alert_manager/alertmanager.yml     
 ~/sei/sei-node-monitoring   setup-pd-key ?  cat prometheus/alert_manager/alertmanager.yml                                               ✓  10358  22:57:06 
global:
  resolve_timeout: 1m

templates: 
- 'templates/*'

route:
  group_by: ['...']
  group_wait: 0s
  group_interval: 5m
  repeat_interval: 1h
  
  routes:
    - receiver: 'seinetwork-rules'
      group_by: ['...']

  receiver: seinetwork-rules

receivers:
- name: 'seinetwork-rules'
  pagerduty_configs:
    - service_key: 'abc123'
```