### PR TITLE
Fix PD source URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
       - '--web.enable-lifecycle'
+      - '--web.external-url=http://${EXTERNAL_URL}:9090/'
     ports:
       - 9090:9090
     networks:
@@ -95,10 +96,10 @@ services:
         source: ./prometheus/alert_manager
         target: /etc/alertmanager
         read_only: true
-    command: [
-      '--config.file=/etc/alertmanager/alertmanager.yml',
-      '--log.level=debug',
-    ]
+    command: 
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--log.level=debug'
+      - '--web.external-url=http://${EXTERNAL_URL}:9093/'
     hostname: 'alertmanager'
     restart: always
 


### PR DESCRIPTION
Deployed this for the atlantic-1 chain already
![image](https://user-images.githubusercontent.com/18161326/183280470-75f1775b-8b02-4a45-bcfc-471bc0dc738c.png)


Created Test Page here: https://seinetwork.pagerduty.com/incidents/Q35H05Y0ZDVM0U 
 --> Click on the source to redirect to prom endpoint and see that it actually shows the query

See that the source URL generated actually works 👍🏻  

Also depends on this PR: https://github.com/sei-protocol/sei-infra/pull/59 