### PR TITLE
Add alert-manager -> discord webhook 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,3 +102,20 @@ services:
       - '--web.external-url=http://${EXTERNAL_URL}:9093/'
     hostname: 'alertmanager'
     restart: always
+
+  # Alertmanager -> Discord
+  # You need to set DISCORD_WEBHOOK
+  alertmanager-discord-bot:
+    image: ghcr.io/brandonweng/alertmanager-discord@sha256:b31270ddf860be2615252aab58d294b689b6e9ad59eb17ec83ef85b3be60f979
+    volumes:
+       # Mount volumes for certs when posting requests to Discord
+        - "/etc/ssl/certs:/etc/ssl/certs:ro"
+    container_name: alertmanager-discord-bot
+    command: [
+      '--webhook=${DISCORD_WEBHOOK}'
+    ]
+    networks:
+        - cosmos-monitoring
+    ports:
+        - 9094:9094
+    restart: always

--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -36,6 +36,7 @@ receivers:
   pagerduty_configs:
     - service_key: 'REPLACE-ME'
 
-- name: 'discord-webhook'
+- name: 'discord_webhook'
   webhook_configs:
-  - url: 'http://localhost:9094'
+    # Point to container name, docker will resolve it to the right container
+    - url: 'http://alertmanager-discord-bot:9094/alerts'

--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -1,7 +1,7 @@
 global:
   resolve_timeout: 1m
 
-templates: 
+templates:
 - 'templates/*'
 
 route:
@@ -9,7 +9,7 @@ route:
   group_wait: 0s
   group_interval: 5m
   repeat_interval: 1h
- 
+
 
   routes:
     - matchers:
@@ -19,8 +19,13 @@ route:
     - matchers:
       - severity="critical"
       receiver: seinetwork-rules
-    
+
+   - matchers:
+      - severity=~"critical|major|testing"
+     receiver: discord-webhook
+
   receiver: seinetwork-rules
+
 
 receivers:
 - name: 'seinetwork-rules'
@@ -30,3 +35,7 @@ receivers:
 - name: 'seinetwork-warning'
   pagerduty_configs:
     - service_key: 'REPLACE-ME'
+
+- name: 'discord-webhook'
+  webhook_configs:
+  - url: 'http://localhost:9094'

--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -22,7 +22,7 @@ route:
 
    - matchers:
       - severity=~"critical|major|testing"
-     receiver: discord-webhook
+     receiver: discord_webhook
 
   receiver: seinetwork-rules
 


### PR DESCRIPTION
Will deploy from master once it merges 

`DISCORD_WEBHOOK` will also need to be set up in our sei-infra provisioning 

Sent some tests to my own server - looks like external URL wasn't setup properly either, will look at that too
![image](https://user-images.githubusercontent.com/18161326/196542813-a0cad0c6-b0c5-43d7-8a13-bf2a8b4e1642.png)
