### PR TITLE
Add LoadTestClientTxsNotCommitted alert

### DIFF
--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -10,8 +10,18 @@ route:
   group_interval: 5m
   repeat_interval: 1h
 
-
   routes:
+    # Internal test chains should only be warnings and page during business hours
+    - matchers:
+      - chain_id="sei-loadtest-testnet"
+      receiver: seinetwork-warning
+    - matchers:
+      - chain_id="sei-internal-testnet-1"
+      receiver: seinetwork-warning
+    - matchers:
+      - chain_id="sei-devnet-1"
+      receiver: seinetwork-warning
+
     - matchers:
       - severity="major"
       receiver: seinetwork-warning
@@ -40,3 +50,5 @@ receivers:
   webhook_configs:
     # Point to container name, docker will resolve it to the right container
     - url: 'http://alertmanager-discord-bot:9094/alerts'
+
+- name: blackhole

--- a/prometheus/alert_manager/alertmanager.yml.TEMPLATE
+++ b/prometheus/alert_manager/alertmanager.yml.TEMPLATE
@@ -14,7 +14,7 @@ route:
     # Internal test chains should only be warnings and page during business hours
     - matchers:
       - chain_id="sei-loadtest-testnet"
-      receiver: seinetwork-warning
+      receiver: blackhole
     - matchers:
       - chain_id="sei-internal-testnet-1"
       receiver: seinetwork-warning

--- a/prometheus/alerts/alert.rules.TEMPLATE
+++ b/prometheus/alerts/alert.rules.TEMPLATE
@@ -201,7 +201,7 @@ groups:
         service: cosmos-monitoring
       annotations:
         description: 'Your validator `{{ $labels.moniker }}` rank is `{{ $value }}`!'
-        
+
     - alert: IsJailed
       expr: cosmos_validator_jailed == 1
       for: 5m
@@ -210,3 +210,11 @@ groups:
         service: cosmos-monitoring
       annotations:
         description: 'Your validator `{{ $labels.moniker }}` is jailed! `{{ $value }}`!'
+
+    - alert: LoadTestClientTxsNotCommitted
+      expr: sum(sum_over_time(loadtest_client_sei_tx_failed[5m]) > 5) by (cluster_name, reason)
+      labels:
+        severity: warning
+        service: loadtest-client
+      annotations:
+        description: 'More than 5 TXs failed in the last 5 minutes in `{{ $labels.cluster_name }}` have failed due to `{{ $labels.reason }}` use `loadtest_client_sei_tx_code` to get more information'


### PR DESCRIPTION
Add an alert for load test clients not committed 

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/18161326/201007742-73d2cb5f-59ac-49c7-ac89-e4942c82752b.png">

There are some alerts here that are firing but I feel like it might not be necessary to alert as some of the reasons are pretty noisy i.e insufficient funds 

Will deploy once it's merged