### PR TITLE
Add alerts for failed concurrent tx validation and approaching upgrade height

### DIFF
--- a/prometheus/alerts/alert.rules
+++ b/prometheus/alerts/alert.rules
@@ -225,3 +225,20 @@ groups:
         service: heatseeker
       annotations:
         description: 'Vortex Front End is unreachable. Please follow oncall sop to debug.'
+
+    - alert: FailedConcurrentTxValidations
+      expr: increase(sei_concurrent_tx_validation_failed[5m]) > 5
+      labels:
+        severity: warning
+        service: cosmos-monitoring
+      annotations:
+        description: 'Multiple failed concurrent TX validations. Please follow oncall sop to debug'
+
+    - alert: ApproachingUpgradeHeight
+      expr: 0 < max(sum(cosmos_upgrade_plan_height) by (chain_id, cluster_name)) - max(sum(tendermint_consensus_latest_block_height) by (chain_id, cluster_name)) < 2000
+      annotations:
+        title: 'Approaching upgrade height'
+        service: cosmos-monitoring
+        description: 'We are 2000 blocks away from the upgrade height defined above. Please prepare to perform upgrade'
+      labels:
+        severity: 'critical'


### PR DESCRIPTION
Adding alerts for failed concurrent TX validation and approaching upgrade height, both these new metrics aren't available in Atlantic-1 so they won't fire, will just be deploying these to the 2.0.0beta test cluster 

![image](https://user-images.githubusercontent.com/18161326/202359919-5e5d613e-99cd-4237-9fd6-93aa57ea4ad2.png)
