### PR TITLE
Bump highblocktime threshold

### DIFF
--- a/prometheus/alerts/alert.rules
+++ b/prometheus/alerts/alert.rules
@@ -45,9 +45,9 @@ groups:
       for: 5m
       labels:
         service: cosmos-exporter
-        severity: critical
+        severity: major
       annotations:
-        description: 'p50 latencies for blocks is greater than 0.75 seconds. Please investigate.'
+        description: 'p50 latencies for blocks is greater than 1 seconds. Please investigate.'
 
     - alert: NodeFilesystemReadonly
       expr: node_filesystem_readonly{fstype!~"rootfs|nfs4"} > 0
@@ -205,7 +205,7 @@ groups:
     - alert: LoadTestClientTxsNotCommitted
       expr: sum(sum_over_time(loadtest_client_sei_tx_failed[5m]) > 5) by (cluster_name, reason)
       labels:
-        severity: warning
+        severity: major
         service: loadtest-client
       annotations:
         description: 'More than 5 TXs failed in the last 5 minutes in `{{ $labels.cluster_name }}` have failed due to `{{ $labels.reason }}` use `loadtest_client_sei_tx_code` to get more information'

--- a/prometheus/alerts/alert.rules
+++ b/prometheus/alerts/alert.rules
@@ -41,7 +41,7 @@ groups:
         description: 'No new blocks have been produced in 5m. Please investigate.'
 
     - alert: HighBlockTimes
-      expr: histogram_quantile(0.5, sum(rate(tendermint_consensus_block_interval_seconds_bucket[5m])) by (le)) > 0.75
+      expr: histogram_quantile(0.5, sum(rate(tendermint_consensus_block_interval_seconds_bucket[5m])) by (le)) > 1
       for: 5m
       labels:
         service: cosmos-exporter


### PR DESCRIPTION
As discussed in our oncall channel, this threshold is no longer worthy of alerting on as we are expecting more load on Atlantic-1